### PR TITLE
Release v0.1.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,10 @@
 # ISCC_SEARCH_WORKERS=
 
 # Auto-flush sub-indexes after N dirty key mutations (0 = disabled).
-# Only safe with a single writer process. Production recommendation: 100000.
-# Reduces blast radius of hard crashes (OOM / SIGKILL / power loss).
-# ISCC_SEARCH_FLUSH_INTERVAL=0
+# Only safe with a single writer process. Default 100000 caps data loss
+# on hard crashes (OOM / SIGKILL / power loss). Set to 0 only if you can
+# tolerate unbounded loss in exchange for slightly faster ingestion.
+# ISCC_SEARCH_FLUSH_INTERVAL=100000
 
 # Log level (debug, info, warning, error, critical)
 # ISCC_SEARCH_LOG_LEVEL=info

--- a/.env.example
+++ b/.env.example
@@ -34,10 +34,10 @@
 # --- Shard Sizes (MB) ---
 
 # Maximum shard file size for ISCC-UNIT indexes
-# ISCC_SEARCH_SHARD_SIZE_UNITS=1024
+# ISCC_SEARCH_SHARD_SIZE_UNITS=512
 
 # Maximum shard file size for simprint indexes
-# ISCC_SEARCH_SHARD_SIZE_SIMPRINTS=1024
+# ISCC_SEARCH_SHARD_SIZE_SIMPRINTS=512
 
 # --- HNSW Parameters (Units) ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New CLI command `iscc-search index rebuild [--unit-type X] [--simprint-type Y] [--all] [--index NAME]`
+    that rebuilds derived NPHD and simprint indexes for a local usearch-backed index from LMDB source data.
+    The "out-of-sync" startup warnings now point at this command instead of an imaginary one. Operators no
+    longer need a Python REPL to recover after a crash that left LMDB ahead of the on-disk shards.
+
 ### Changed
 
 - **Breaking default**: `ISCC_SEARCH_FLUSH_INTERVAL` default raised from `0` (disabled) to `100000`. Derived
@@ -31,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `UsearchIndexManager` and `LmdbIndexManager` now serialize first-load construction in
+    `_get_or_load_index` with a `threading.Lock`. Previously, a concurrent burst against an uncached index
+    (typical first-burst-after-restart) could race two threads into `lmdb.open()` on the same path,
+    producing `lmdb.Error: The environment '...index.lmdb' is already open in this process` and a 500
+    response. Once one thread populated the cache, subsequent requests were fine — so this only affected
+    first bursts, but those are exactly when operators are paying attention.
 - Deployment troubleshooting docs no longer instruct operators to delete `.usearch` files to trigger an
     auto-rebuild on restart. Auto-rebuild on startup was disabled in v0.1.0 to prevent OOM restart loops on
     large indexes; the docs now describe the explicit rebuild procedure from LMDB instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking default**: `ISCC_SEARCH_FLUSH_INTERVAL` default raised from `0` (disabled) to `100000`. Derived
+    HNSW indexes (NPHD, simprint) now auto-flush every 100,000 dirty mutations, capping data loss on hard
+    crashes (OOM, SIGKILL, power loss). Previously, indexes were only saved on graceful `close()` — small
+    indexes that never reached the shard-size rotation threshold could lose every vector added since process
+    start. Set `ISCC_SEARCH_FLUSH_INTERVAL=0` to restore the old behavior if you need maximum ingestion
+    throughput and can tolerate unbounded loss on crash.
+- Repo `compose.yaml` `stop_grace_period` raised from `90s` to `300s`. uvicorn shutdown is sequential —
+    request drain (bounded by `--timeout-graceful-shutdown`, kept at `60s`) runs first, then the lifespan
+    handler runs the HNSW flush with no uvicorn-side timeout. Docker's `stop_grace_period` is the only
+    outer bound on the flush, so it must be `>= timeout_graceful_shutdown + expected_flush_duration`. The
+    new `300s` covers `60s` drain plus `~240s` flush headroom; raise to `600s+` for indexes over 10M
+    vectors. If your production compose file overrides `stop_grace_period`, recalculate using this formula.
+
+### Fixed
+
+- Deployment troubleshooting docs no longer instruct operators to delete `.usearch` files to trigger an
+    auto-rebuild on restart. Auto-rebuild on startup was disabled in v0.1.0 to prevent OOM restart loops on
+    large indexes; the docs now describe the explicit rebuild procedure from LMDB instead.
+
 ## [0.1.0] - 2026-04-16
 
 Initial release of iscc-search.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking default**: `ISCC_SEARCH_FLUSH_INTERVAL` default raised from `0` (disabled) to `100000`. Derived
-    HNSW indexes (NPHD, simprint) now auto-flush every 100,000 dirty mutations, capping data loss on hard
-    crashes (OOM, SIGKILL, power loss). Previously, indexes were only saved on graceful `close()` — small
-    indexes that never reached the shard-size rotation threshold could lose every vector added since process
-    start. Set `ISCC_SEARCH_FLUSH_INTERVAL=0` to restore the old behavior if you need maximum ingestion
-    throughput and can tolerate unbounded loss on crash.
+    HNSW indexes (NPHD, simprint) now auto-flush every 100,000 dirty mutations. Previously, indexes were
+    only saved on graceful `close()` — small indexes that never reached the shard-size rotation threshold
+    could lose every vector added since process start, leaving the server with 0% of recent data searchable
+    after a crash until a manual rebuild completed. With the new default, the post-crash gap is bounded to
+    ~100K vectors per sub-index, so the server remains in degraded-but-mostly-functional state and can
+    serve queries while a rebuild is scheduled. Note: this **does not reduce rebuild cost** — current
+    `_rebuild_nphd_index` / `_rebuild_simprint_index` are destructive (rmtree the shard dir, re-add
+    everything from LMDB) and rebuild the full per-type vector set regardless of how much was already
+    persisted. An incremental repair path that exploits the persisted state via per-shard bloom filters is
+    planned. Trade-off: ~25× write amplification on heavy SIMPRINT ingestion. Set
+    `ISCC_SEARCH_FLUSH_INTERVAL=0` to restore the old behavior if you need maximum ingestion throughput
+    and accept unbounded loss on crash.
 - Repo `compose.yaml` `stop_grace_period` raised from `90s` to `300s`. uvicorn shutdown is sequential —
     request drain (bounded by `--timeout-graceful-shutdown`, kept at `60s`) runs first, then the lifespan
     handler runs the HNSW flush with no uvicorn-side timeout. Docker's `stop_grace_period` is the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2026-05-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     planned. Trade-off: ~25× write amplification on heavy SIMPRINT ingestion. Set
     `ISCC_SEARCH_FLUSH_INTERVAL=0` to restore the old behavior if you need maximum ingestion throughput
     and accept unbounded loss on crash.
+- **Breaking default**: `ISCC_SEARCH_SHARD_SIZE_UNITS` and `ISCC_SEARCH_SHARD_SIZE_SIMPRINTS` defaults
+    lowered from `1024` MB to `512` MB. Smaller rotation threshold means active shards seal to immutable
+    on-disk artifacts roughly twice as often, so the worst-case "active shard lost on crash" window shrinks
+    by ~50% for high-volume simprint ingestion. Complementary to the `flush_interval` change above:
+    `flush_interval` bounds loss by *mutation count* on the live active shard; `shard_size_*` bounds loss
+    by *bytes sealed*. Trade-off: ~2× the number of sealed shard files on disk, marginally more I/O on
+    rotation. Existing deployments need no migration: sealed shards from the old 1024 MB era stay
+    untouched (they are never split or rewritten), and an active shard already above 512 MB simply
+    rotates on its next `add()`. Expect heterogeneous shard sizes in directories that span the
+    transition. Set explicitly to `1024` to restore the old behavior.
 - Repo `compose.yaml` `stop_grace_period` raised from `90s` to `300s`. uvicorn shutdown is sequential —
     request drain (bounded by `--timeout-graceful-shutdown`, kept at `60s`) runs first, then the lifespan
     handler runs the HNSW flush with no uvicorn-side timeout. Docker's `stop_grace_period` is the only

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,16 @@ RUN mkdir -p /data
 ENV ISCC_SEARCH_INDEX_URI=usearch:///data
 
 # Single worker only: usearch indexes have no multi-process coordination.
-# 60s graceful shutdown lets large indexes save cleanly.
+#
+# Shutdown timing: uvicorn drains in-flight requests for up to
+# --timeout-graceful-shutdown seconds, THEN runs the FastAPI lifespan handler
+# (which calls index.close() to flush HNSW shards). The lifespan handler is
+# UNBOUNDED in uvicorn — only Docker's stop_grace_period can stop it.
+#
+# Therefore: compose stop_grace_period must be >= this drain timeout PLUS the
+# expected flush duration. Default 60s drain assumes typical request latency
+# under a minute; combine with a generous stop_grace_period (>=300s) on the
+# compose side to leave room for the flush.
 CMD ["uvicorn", "iscc_search.server:app", \
      "--host", "0.0.0.0", \
      "--port", "8000", \

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,9 +21,15 @@ services:
     restart: unless-stopped
 
     # Graceful shutdown configuration (CRITICAL for data integrity)
-    # Gives container 90s to save indexes before forced kill
-    # Must be > uvicorn's --timeout-graceful-shutdown (60s)
-    stop_grace_period: 90s
+    #
+    # uvicorn shutdown is sequential: drain in-flight requests (up to
+    # --timeout-graceful-shutdown=60s in the Dockerfile), THEN run the lifespan
+    # handler that flushes HNSW shards (unbounded in uvicorn).
+    #
+    # Required: stop_grace_period >= 60s drain + expected flush + buffer.
+    # 300s = 60s drain + 240s flush headroom. Sufficient for indexes up to
+    # several million vectors; raise to 600s+ for 10M+ vector deployments.
+    stop_grace_period: 300s
 
     # Health check monitors application availability
     healthcheck:

--- a/docs/howto/deployment.md
+++ b/docs/howto/deployment.md
@@ -39,22 +39,15 @@ services:
     image: ghcr.io/iscc/iscc-search:latest
     container_name: iscc-search-api
     ports:
-      - "8000:8000"
+      - 8000:8000
     volumes:
       - iscc-data:/data
     environment:
       - ISCC_SEARCH_INDEX_URI=usearch:///data
-      - ISCC_SEARCH_FLUSH_INTERVAL=100000
       # - ISCC_SEARCH_API_SECRET=your-secret-key
       # - ISCC_SEARCH_CORS_ORIGINS=https://example.com
     restart: unless-stopped
-    stop_grace_period: 120s
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz')"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    stop_grace_period: 300s
     deploy:
       resources:
         limits:
@@ -77,46 +70,63 @@ docker compose up -d
 
 ## Graceful shutdown
 
-On shutdown, iscc-search flushes all dirty HNSW indexes to disk. Large indexes can take tens of seconds to
-save. You must give the process enough time to complete.
+On shutdown, iscc-search flushes all dirty HNSW indexes to disk. Large indexes can take a few minutes to
+save. You must give the process enough time to complete the **drain phase plus the flush phase**.
 
-The timing chain works like this:
+uvicorn's shutdown is **strictly sequential**:
 
-1. **uvicorn** `--timeout-graceful-shutdown 60` - stops accepting connections, waits up to 60s for the
-   lifespan handler to flush indexes.
-2. **Docker** `stop_grace_period: 120s` - sends SIGTERM, then waits 120s before SIGKILL. Must be longer
-   than uvicorn's timeout.
+1. **uvicorn** stops accepting new connections (immediate).
+1. **uvicorn** waits for in-flight requests to complete, bounded by `--timeout-graceful-shutdown`.
+1. **uvicorn** runs the FastAPI lifespan handler, which calls `index.close()` to flush HNSW shards.
+    This step has **no timeout in uvicorn** — only Docker's `stop_grace_period` can stop it.
+1. **Docker** sends SIGKILL once `stop_grace_period` elapses since the initial SIGTERM.
 
-The Dockerfile sets `--timeout-graceful-shutdown 60` by default. Set `stop_grace_period` in your compose file
-to at least double that value.
+This means:
+
+```
+stop_grace_period >= timeout_graceful_shutdown + expected_flush_duration + buffer
+```
+
+If `stop_grace_period` equals `timeout_graceful_shutdown`, a slow request can consume the entire grace
+window and Docker SIGKILLs the process the moment the lifespan flush tries to start, **losing all dirty
+HNSW state**. This is a real failure mode, not a theoretical one.
+
+Defaults:
+
+- Dockerfile: `--timeout-graceful-shutdown 60` (drain timeout)
+- compose.yaml: `stop_grace_period 300s` (60s drain + 240s flush headroom)
+
+For very large indexes (10M+ vectors), raise `stop_grace_period` to `600s` or more — the drain timeout
+stays at `60s` because it bounds request latency, not flush latency.
 
 ## Environment variables
 
-| Variable | Default | Production recommendation |
-|---|---|---|
-| `ISCC_SEARCH_INDEX_URI` | `usearch://` + platform dir | `usearch:///data` (explicit path) |
-| `ISCC_SEARCH_API_SECRET` | None (public) | Set a strong secret |
-| `ISCC_SEARCH_CORS_ORIGINS` | `*` | Restrict to your domains |
-| `ISCC_SEARCH_FLUSH_INTERVAL` | 0 (disabled) | `100000` (flush every 100K mutations) |
-| `ISCC_SEARCH_LOG_LEVEL` | `info` | `info` or `warning` |
-| `ISCC_SEARCH_SENTRY_DSN` | None | Set for error tracking |
-| `ISCC_SEARCH_HOST` | `0.0.0.0` | `0.0.0.0` |
-| `ISCC_SEARCH_PORT` | 8000 | 8000 |
+| Variable                     | Default                     | Production recommendation                             |
+| ---------------------------- | --------------------------- | ----------------------------------------------------- |
+| `ISCC_SEARCH_INDEX_URI`      | `usearch://` + platform dir | `usearch:///data` (explicit path)                     |
+| `ISCC_SEARCH_API_SECRET`     | None (public)               | Set a strong secret                                   |
+| `ISCC_SEARCH_CORS_ORIGINS`   | `*`                         | Restrict to your domains                              |
+| `ISCC_SEARCH_FLUSH_INTERVAL` | `100000`                    | Keep at default, or raise for higher write throughput |
+| `ISCC_SEARCH_LOG_LEVEL`      | `info`                      | `info` or `warning`                                   |
+| `ISCC_SEARCH_SENTRY_DSN`     | None                        | Set for error tracking                                |
+| `ISCC_SEARCH_HOST`           | `0.0.0.0`                   | `0.0.0.0`                                             |
+| `ISCC_SEARCH_PORT`           | 8000                        | 8000                                                  |
 
 !!! tip "Flush interval"
 
-    `FLUSH_INTERVAL=0` means indexes are only saved on graceful shutdown. If the process is killed (OOM,
-    SIGKILL, power loss), all mutations since the last save are lost. Setting a non-zero value reduces the
-    blast radius of hard crashes.
+    The default `FLUSH_INTERVAL=100000` auto-flushes derived HNSW indexes every 100,000 mutations, capping
+    data loss on hard crashes (OOM, SIGKILL, power loss). Setting it to `0` disables auto-flush and means
+    indexes are only saved on graceful shutdown — faster ingestion but unbounded loss on crash. Raise the
+    value for slightly higher write throughput at the cost of a larger loss window.
 
 ## Sizing profiles
 
-| Profile | Assets | RAM | CPU | Notes |
-|---|---|---|---|---|
-| Sandbox | up to 100K | 4 GB | 2 cores | Development and testing |
-| Validation | up to 500K | 64 GB | 4 cores | Pre-production validation |
-| Launch | up to 1M | 128 GB | 8 cores | Initial production deployment |
-| Growth | 5M+ | 256 GB+ | 16+ cores | Large-scale production |
+| Profile    | Assets     | RAM     | CPU       | Notes                         |
+| ---------- | ---------- | ------- | --------- | ----------------------------- |
+| Sandbox    | up to 100K | 4 GB    | 2 cores   | Development and testing       |
+| Validation | up to 500K | 64 GB   | 4 cores   | Pre-production validation     |
+| Launch     | up to 1M   | 128 GB  | 8 cores   | Initial production deployment |
+| Growth     | 5M+        | 256 GB+ | 16+ cores | Large-scale production        |
 
 HNSW indexes are memory-mapped. RAM requirements grow with index size. Monitor RSS and adjust limits.
 
@@ -177,10 +187,11 @@ Before going live, verify the following:
 
 - [ ] `ISCC_SEARCH_INDEX_URI` points to a persistent volume
 - [ ] Worker count is 1 (or unset)
-- [ ] `ISCC_SEARCH_FLUSH_INTERVAL` is non-zero (e.g., `100000`)
+- [ ] `ISCC_SEARCH_FLUSH_INTERVAL` is non-zero (default `100000`)
 - [ ] `ISCC_SEARCH_API_SECRET` is set
 - [ ] `ISCC_SEARCH_CORS_ORIGINS` is restricted to your domains
-- [ ] `stop_grace_period` is at least 2x the uvicorn graceful shutdown timeout
+- [ ] `stop_grace_period` is `>= timeout_graceful_shutdown + expected_flush_duration` (default `300s`
+    covers ~60s drain + ~240s flush; raise for indexes over 10M vectors)
 - [ ] Health probes are configured in your orchestrator
 - [ ] Each instance has its own data volume (no sharing)
 - [ ] Resource limits (CPU, memory) match your sizing profile
@@ -189,15 +200,46 @@ Before going live, verify the following:
 
 ## Troubleshooting
 
-### Index corruption
+### Derived indexes out of sync
 
-**Symptom**: Server crashes on startup, search returns errors, or asset counts are wrong.
+**Symptom**: Boot logs show `ShardedNphdIndex 'X' out of sync: expected N vectors, found M` or
+`UsearchSimprintIndex 'X' out of sync: expected N, found M`. Search results are stale or empty for affected
+unit/simprint types. Asset counts in `/indexes` reflect LMDB and may be larger than what searches return.
 
-**Cause**: Multiple processes wrote to the same data directory, or the process was killed during a write
-(SIGKILL, OOM).
+**Cause**: The process was killed (SIGKILL, OOM, host crash, `stop_grace_period` too short) before the
+lifespan handler could flush dirty HNSW shards to disk. LMDB is the source of truth and survives unclean
+exits; derived HNSW shards do not unless they were saved by `flush_interval` rotation, shard-size rotation,
+or graceful `close()`.
 
-**Fix**: Stop the server. Delete the corrupted `.usearch` files from the index directory. Restart the server.
-It will rebuild HNSW indexes from the LMDB data on next access. Re-index if LMDB is also corrupted.
+**Fix**: Stop the server, then run an explicit rebuild from the intact LMDB data. Auto-rebuild on startup is
+intentionally disabled because rebuilding large indexes can OOM the container.
+
+```python
+# One-shot rebuild from a Python REPL or script (until the CLI command lands)
+from iscc_search.indexes.usearch.index import UsearchIndex
+
+idx = UsearchIndex("/path/to/index-dir")
+for unit_type in ("META_NONE_V0", "DATA_NONE_V0", "CONTENT_TEXT_V0", "SEMANTIC_TEXT_V0"):
+    idx._rebuild_nphd_index(unit_type)
+for sp_type in ("CONTENT_TEXT_V0", "SEMANTIC_TEXT_V0"):
+    idx._rebuild_simprint_index(sp_type)
+idx.close()
+```
+
+Restart the server. To prevent recurrence, ensure `ISCC_SEARCH_FLUSH_INTERVAL` is set to a non-zero value
+(default `100000`) and `stop_grace_period` is sized as
+`timeout_graceful_shutdown + expected_flush_duration + buffer` (default `60s + 240s = 300s`).
+
+### LMDB corruption
+
+**Symptom**: Server crashes on startup with `lmdb.Error` reading `index.lmdb`, or asset retrieval returns
+malformed data.
+
+**Cause**: Disk corruption, killed mid-write at the LMDB layer (very rare — LMDB uses MVCC and is
+crash-safe by design), or downgrading the LMDB version with on-disk format incompatibility.
+
+**Fix**: Restore `index.lmdb` from backup, then run the rebuild procedure above to regenerate derived
+indexes. Re-ingest if no backup is available.
 
 ### Slow shutdown
 
@@ -205,8 +247,10 @@ It will rebuild HNSW indexes from the LMDB data on next access. Re-index if LMDB
 
 **Cause**: Large HNSW indexes need time to flush to disk. The grace period is too short.
 
-**Fix**: Increase `stop_grace_period` in your compose file. For indexes over 1M assets, use 300s or more.
-Monitor shutdown logs to find the actual flush duration.
+**Fix**: Raise `stop_grace_period` in your compose file. Keep `--timeout-graceful-shutdown` at the default
+`60s` (it bounds request drain, not flush). Use the formula
+`stop_grace_period = 60s + measured_flush_duration + 60s buffer`. Monitor shutdown logs
+(`Saved ShardedNphdIndex`, `Saved UsearchSimprintIndex`) to measure actual flush duration.
 
 ### Out of memory
 

--- a/docs/howto/index-backends.md
+++ b/docs/howto/index-backends.md
@@ -77,20 +77,20 @@ Each index is a directory containing an LMDB file plus `.usearch` shard files fo
 
 You can tune HNSW parameters via environment variables:
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `ISCC_SEARCH_HNSW_CONNECTIVITY_UNITS` | 16 | Graph connectivity (M) for unit indexes |
-| `ISCC_SEARCH_HNSW_EXPANSION_ADD_UNITS` | 128 | Build-time search depth (efConstruction) |
-| `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_UNITS` | 64 | Query-time search depth (ef) |
-| `ISCC_SEARCH_SHARD_SIZE_UNITS` | 1024 | Max shard file size in MB |
+| Variable                                  | Default | Purpose                                  |
+| ----------------------------------------- | ------- | ---------------------------------------- |
+| `ISCC_SEARCH_HNSW_CONNECTIVITY_UNITS`     | 16      | Graph connectivity (M) for unit indexes  |
+| `ISCC_SEARCH_HNSW_EXPANSION_ADD_UNITS`    | 128     | Build-time search depth (efConstruction) |
+| `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_UNITS` | 64      | Query-time search depth (ef)             |
+| `ISCC_SEARCH_SHARD_SIZE_UNITS`            | 512     | Max shard file size in MB                |
 
 ## Choosing a backend
 
-| Backend | URI | Persistence | Search type | Best for |
-|---|---|---|---|---|
-| Memory | `memory://` | None | Exact | Tests, demos, prototyping |
-| LMDB | `lmdb:///path` | Disk | Prefix search | Small datasets, exact lookup |
-| USearch | `usearch:///path` | Disk | HNSW similarity | Production similarity search |
+| Backend | URI               | Persistence | Search type     | Best for                     |
+| ------- | ----------------- | ----------- | --------------- | ---------------------------- |
+| Memory  | `memory://`       | None        | Exact           | Tests, demos, prototyping    |
+| LMDB    | `lmdb:///path`    | Disk        | Prefix search   | Small datasets, exact lookup |
+| USearch | `usearch:///path` | Disk        | HNSW similarity | Production similarity search |
 
 For most production deployments, use the usearch backend. Use LMDB when you need prefix-based lookup without
 similarity search. Use memory for automated tests.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,8 +24,8 @@ direct instantiation in code.
 | `ISCC_SEARCH_HOST`                            | `0.0.0.0`              | Server bind address                                |
 | `ISCC_SEARCH_PORT`                            | `8000`                 | Server bind port                                   |
 | `ISCC_SEARCH_WORKERS`                         | `None`                 | Number of worker processes                         |
-| `ISCC_SEARCH_SHARD_SIZE_UNITS`                | `1024`                 | Max shard size for unit indexes (MB)               |
-| `ISCC_SEARCH_SHARD_SIZE_SIMPRINTS`            | `1024`                 | Max shard size for simprint indexes (MB)           |
+| `ISCC_SEARCH_SHARD_SIZE_UNITS`                | `512`                  | Max shard size for unit indexes (MB)               |
+| `ISCC_SEARCH_SHARD_SIZE_SIMPRINTS`            | `512`                  | Max shard size for simprint indexes (MB)           |
 | `ISCC_SEARCH_HNSW_EXPANSION_ADD_UNITS`        | `128`                  | Build-time search depth for unit HNSW              |
 | `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_UNITS`     | `64`                   | Query-time search depth for unit HNSW              |
 | `ISCC_SEARCH_HNSW_CONNECTIVITY_UNITS`         | `16`                   | Graph connectivity (M) for unit HNSW               |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,30 +16,30 @@ use the `ISCC_SEARCH_` prefix and follow 12-factor app principles.
 You can set these through environment variables, a `.env` file in the working directory, or
 direct instantiation in code.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ISCC_SEARCH_INDEX_URI` | `usearch://{data_dir}` | Backend URI (`memory://`, `lmdb://`, `usearch://`) |
-| `ISCC_SEARCH_API_SECRET` | `None` | API authentication secret (unset = public access) |
-| `ISCC_SEARCH_CORS_ORIGINS` | `*` | Comma-separated allowed origins |
-| `ISCC_SEARCH_HOST` | `0.0.0.0` | Server bind address |
-| `ISCC_SEARCH_PORT` | `8000` | Server bind port |
-| `ISCC_SEARCH_WORKERS` | `None` | Number of worker processes |
-| `ISCC_SEARCH_SHARD_SIZE_UNITS` | `1024` | Max shard size for unit indexes (MB) |
-| `ISCC_SEARCH_SHARD_SIZE_SIMPRINTS` | `1024` | Max shard size for simprint indexes (MB) |
-| `ISCC_SEARCH_HNSW_EXPANSION_ADD_UNITS` | `128` | Build-time search depth for unit HNSW |
-| `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_UNITS` | `64` | Query-time search depth for unit HNSW |
-| `ISCC_SEARCH_HNSW_CONNECTIVITY_UNITS` | `16` | Graph connectivity (M) for unit HNSW |
-| `ISCC_SEARCH_HNSW_EXPANSION_ADD_SIMPRINTS` | `16` | Build-time search depth for simprint HNSW |
-| `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_SIMPRINTS` | `512` | Query-time search depth for simprint HNSW |
-| `ISCC_SEARCH_HNSW_CONNECTIVITY_SIMPRINTS` | `8` | Graph connectivity (M) for simprint HNSW |
-| `ISCC_SEARCH_MATCH_THRESHOLD_UNITS` | `0.75` | Minimum score for unit matches (0.0-1.0) |
-| `ISCC_SEARCH_MATCH_THRESHOLD_SIMPRINTS` | `0.75` | Minimum score for simprint matches (0.0-1.0) |
-| `ISCC_SEARCH_CONFIDENCE_EXPONENT` | `4` | Exponent for confidence-weighted scoring |
-| `ISCC_SEARCH_OVERSAMPLING_FACTOR` | `20` | Oversampling multiplier for simprint search |
-| `ISCC_SEARCH_FLUSH_INTERVAL` | `0` | Auto-flush after N mutations (0 = disabled) |
-| `ISCC_SEARCH_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warning`, `error`) |
-| `ISCC_SEARCH_SENTRY_DSN` | `None` | Sentry error tracking DSN |
-| `ISCC_SEARCH_SENTRY_TRACES_SAMPLE_RATE` | `0.05` | Sentry performance sampling rate (0.0-1.0) |
+| Variable                                      | Default                | Description                                        |
+| --------------------------------------------- | ---------------------- | -------------------------------------------------- |
+| `ISCC_SEARCH_INDEX_URI`                       | `usearch://{data_dir}` | Backend URI (`memory://`, `lmdb://`, `usearch://`) |
+| `ISCC_SEARCH_API_SECRET`                      | `None`                 | API authentication secret (unset = public access)  |
+| `ISCC_SEARCH_CORS_ORIGINS`                    | `*`                    | Comma-separated allowed origins                    |
+| `ISCC_SEARCH_HOST`                            | `0.0.0.0`              | Server bind address                                |
+| `ISCC_SEARCH_PORT`                            | `8000`                 | Server bind port                                   |
+| `ISCC_SEARCH_WORKERS`                         | `None`                 | Number of worker processes                         |
+| `ISCC_SEARCH_SHARD_SIZE_UNITS`                | `1024`                 | Max shard size for unit indexes (MB)               |
+| `ISCC_SEARCH_SHARD_SIZE_SIMPRINTS`            | `1024`                 | Max shard size for simprint indexes (MB)           |
+| `ISCC_SEARCH_HNSW_EXPANSION_ADD_UNITS`        | `128`                  | Build-time search depth for unit HNSW              |
+| `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_UNITS`     | `64`                   | Query-time search depth for unit HNSW              |
+| `ISCC_SEARCH_HNSW_CONNECTIVITY_UNITS`         | `16`                   | Graph connectivity (M) for unit HNSW               |
+| `ISCC_SEARCH_HNSW_EXPANSION_ADD_SIMPRINTS`    | `16`                   | Build-time search depth for simprint HNSW          |
+| `ISCC_SEARCH_HNSW_EXPANSION_SEARCH_SIMPRINTS` | `512`                  | Query-time search depth for simprint HNSW          |
+| `ISCC_SEARCH_HNSW_CONNECTIVITY_SIMPRINTS`     | `8`                    | Graph connectivity (M) for simprint HNSW           |
+| `ISCC_SEARCH_MATCH_THRESHOLD_UNITS`           | `0.75`                 | Minimum score for unit matches (0.0-1.0)           |
+| `ISCC_SEARCH_MATCH_THRESHOLD_SIMPRINTS`       | `0.75`                 | Minimum score for simprint matches (0.0-1.0)       |
+| `ISCC_SEARCH_CONFIDENCE_EXPONENT`             | `4`                    | Exponent for confidence-weighted scoring           |
+| `ISCC_SEARCH_OVERSAMPLING_FACTOR`             | `20`                   | Oversampling multiplier for simprint search        |
+| `ISCC_SEARCH_FLUSH_INTERVAL`                  | `100000`               | Auto-flush after N mutations (0 = disabled)        |
+| `ISCC_SEARCH_LOG_LEVEL`                       | `info`                 | Log level (`debug`, `info`, `warning`, `error`)    |
+| `ISCC_SEARCH_SENTRY_DSN`                      | `None`                 | Sentry error tracking DSN                          |
+| `ISCC_SEARCH_SENTRY_TRACES_SAMPLE_RATE`       | `0.05`                 | Sentry performance sampling rate (0.0-1.0)         |
 
 ### .env file support
 
@@ -117,9 +117,9 @@ Local indexes store `path` (directory on disk). Remote indexes store `url` and o
 These configuration systems are intentionally separate.
 
 - **`SearchOptions`** drives the server. One index per deployment, configured through
-  environment variables. Used by `iscc-search serve`.
+    environment variables. Used by `iscc-search serve`.
 - **`AppConfig`** drives the CLI. Multiple named indexes with an active selection, persisted
-  in JSON. Used by `iscc-search add`, `search`, `get`.
+    in JSON. Used by `iscc-search add`, `search`, `get`.
 
 See [Architecture](../explanation/architecture.md) for how these systems fit into the
 overall design.

--- a/iscc_search/cli/__init__.py
+++ b/iscc_search/cli/__init__.py
@@ -31,6 +31,7 @@ index_app.command(name="add")(index.add_command)
 index_app.command(name="list")(index.list_command)
 index_app.command(name="use")(index.use_command)
 index_app.command(name="remove")(index.remove_command)
+index_app.command(name="rebuild")(index.rebuild_command)
 
 # Register commands
 app.add_typer(index_app, name="index")

--- a/iscc_search/cli/index.py
+++ b/iscc_search/cli/index.py
@@ -13,12 +13,13 @@ from pathlib import Path
 import typer
 from rich.table import Table
 
-from iscc_search.cli.common import console
+from iscc_search.cli.common import console, get_active_index
 from iscc_search.config import (
     LocalIndexConfig,
     RemoteIndexConfig,
     get_config_manager,
 )
+from iscc_search.indexes.usearch import UsearchIndexManager
 
 
 def add_command(
@@ -166,6 +167,98 @@ def use_command(name: str):
         console.print(f"[red]Error: {e}[/red]")
         console.print("Use 'iscc-search index list' to see available indexes")
         sys.exit(1)
+
+
+def rebuild_command(
+    unit_type: list[str] = typer.Option(
+        [],
+        "--unit-type",
+        help="NPHD unit_type to rebuild (repeatable, e.g. CONTENT_TEXT_V0)",
+    ),
+    simprint_type: list[str] = typer.Option(
+        [],
+        "--simprint-type",
+        help="Simprint type to rebuild (repeatable, e.g. CONTENT_TEXT_V0)",
+    ),
+    all_types: bool = typer.Option(
+        False,
+        "--all",
+        help="Rebuild every NPHD unit_type and simprint type tracked in LMDB",
+    ),
+    index_name: str | None = typer.Option(
+        None,
+        "--index",
+        help="Index name to use (overrides active index)",
+    ),
+):
+    # type: (...) -> None
+    """
+    Rebuild derived NPHD/simprint indexes for a local index from LMDB source data.
+
+    Each rebuild is destructive for the targeted shard directory: it is removed
+    and the index is rebuilt from scratch using the assets stored in LMDB.
+    Search results for a given type are empty while that type is rebuilding.
+
+    Examples:
+
+        # Rebuild a single NPHD unit type
+        iscc-search index rebuild --unit-type CONTENT_TEXT_V0
+
+        # Rebuild a single simprint type
+        iscc-search index rebuild --simprint-type CONTENT_TEXT_V0
+
+        # Rebuild specific types (mix of NPHD and simprint)
+        iscc-search index rebuild --unit-type META_NONE_V0 --simprint-type CONTENT_TEXT_V0
+
+        # Rebuild every tracked type
+        iscc-search index rebuild --all
+
+        # Operate on a specific index instead of the active one
+        iscc-search index rebuild --all --index myindex
+    """
+    if not unit_type and not simprint_type and not all_types:
+        console.print("[red]Error: specify at least one of --unit-type, --simprint-type, or --all[/red]")
+        sys.exit(1)
+
+    if all_types and (unit_type or simprint_type):
+        console.print("[red]Error: --all cannot be combined with --unit-type or --simprint-type[/red]")
+        sys.exit(1)
+
+    try:
+        manager, target_name = get_active_index(index_name)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+    if not isinstance(manager, UsearchIndexManager):
+        console.print("[red]Error: rebuild is only supported for local usearch indexes[/red]")
+        sys.exit(1)
+
+    try:
+        if all_types:
+            result = manager.rebuild(target_name)
+        else:
+            result = manager.rebuild(
+                target_name,
+                unit_types=list(unit_type),
+                simprint_types=list(simprint_type),
+            )
+    except FileNotFoundError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+    finally:
+        manager.close()
+
+    rebuilt_unit = result["unit_types"]
+    rebuilt_sp = result["simprint_types"]
+    if not rebuilt_unit and not rebuilt_sp:
+        console.print(f"[yellow]No tracked types matched - nothing rebuilt for index '{target_name}'.[/yellow]")
+        return
+
+    if rebuilt_unit:
+        console.print(f"[green]Rebuilt NPHD: {', '.join(rebuilt_unit)}[/green]")
+    if rebuilt_sp:
+        console.print(f"[green]Rebuilt simprint: {', '.join(rebuilt_sp)}[/green]")
 
 
 def remove_command(

--- a/iscc_search/indexes/lmdb/manager.py
+++ b/iscc_search/indexes/lmdb/manager.py
@@ -8,6 +8,7 @@ Implements IsccIndexProtocol for use as backend in CLI and server.
 """
 
 import os
+import threading
 from pathlib import Path
 from iscc_search.schema import IsccIndex
 from iscc_search.indexes.lmdb.index import LmdbIndex
@@ -44,6 +45,9 @@ class LmdbIndexManager:
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
         self._index_cache = {}  # type: dict[str, LmdbIndex]
+        # Serialize first-load construction so concurrent requests don't race on lmdb.open()
+        # (which raises "already open in this process" if two threads call it simultaneously).
+        self._cache_lock = threading.Lock()
 
     def list_indexes(self):
         # type: () -> list[IsccIndex]
@@ -205,16 +209,23 @@ class LmdbIndexManager:
         """
         Get cached index or load from disk.
 
+        Thread-safe: a lock guards the cache-miss construction path so concurrent
+        first-burst requests don't race on lmdb.open() (which raises
+        "already open in this process" if two threads call it simultaneously).
+
         :param name: Index name
         :return: LmdbIndex instance
         """
         if name in self._index_cache:
             return self._index_cache[name]
 
-        index_path = self.base_path / f"{name}.lmdb"
-        idx = LmdbIndex(index_path)
-        self._index_cache[name] = idx
-        return idx
+        with self._cache_lock:
+            if name in self._index_cache:
+                return self._index_cache[name]
+            index_path = self.base_path / f"{name}.lmdb"
+            idx = LmdbIndex(index_path)
+            self._index_cache[name] = idx
+            return idx
 
     def _validate_index_exists(self, name):
         # type: (str) -> None

--- a/iscc_search/indexes/usearch/index.py
+++ b/iscc_search/indexes/usearch/index.py
@@ -698,6 +698,44 @@ class UsearchIndex:
         """Get current LMDB map_size."""
         return self.env.info()["map_size"]
 
+    @property
+    def tracked_unit_types(self):
+        # type: () -> list[str]
+        """Sorted list of NPHD unit_types tracked in LMDB metadata."""
+        return sorted(self._get_all_tracked_unit_types())
+
+    @property
+    def tracked_simprint_types(self):
+        # type: () -> list[str]
+        """Sorted list of simprint types tracked in LMDB metadata."""
+        return sorted(self._get_sp_types())
+
+    def rebuild(self, unit_types, simprint_types):
+        # type: (list[str], list[str]) -> dict[str, list[str]]
+        """
+        Rebuild specified derived indexes from LMDB source data.
+
+        Each NPHD unit_type and simprint_type is rebuilt fresh: the existing shard
+        directory is removed and a new index is built from LMDB entries. Use the
+        ``tracked_unit_types`` and ``tracked_simprint_types`` properties to discover
+        what is currently tracked.
+
+        :param unit_types: NPHD unit_types to rebuild (e.g., ["CONTENT_TEXT_V0"])
+        :param simprint_types: Simprint types to rebuild (e.g., ["CONTENT_TEXT_V0"])
+        :return: Dict with lists of types that were actually rebuilt
+        """
+        rebuilt_unit_types = []  # type: list[str]
+        for unit_type in unit_types:
+            if self._rebuild_nphd_index(unit_type):
+                rebuilt_unit_types.append(unit_type)
+
+        rebuilt_simprint_types = []  # type: list[str]
+        for sp_type in simprint_types:
+            if self._rebuild_simprint_index(sp_type):
+                rebuilt_simprint_types.append(sp_type)
+
+        return {"unit_types": rebuilt_unit_types, "simprint_types": rebuilt_simprint_types}
+
     def _search_simprints(self, query, limit, exact=False):
         # type: (IsccQuery, int, bool) -> list[IsccChunkMatch]
         """
@@ -1248,7 +1286,8 @@ class UsearchIndex:
                     logger.warning(
                         f"ShardedNphdIndex '{unit_type}' out of sync: "
                         f"expected {expected_count} vectors, found {actual_count}. "
-                        f"Skipping auto-rebuild (use CLI rebuild command to fix)."
+                        f"Skipping auto-rebuild. Run 'iscc-search index rebuild "
+                        f"--unit-type {unit_type}' (or '--all') to repair."
                     )
                     # Accept stale index rather than risk OOM during rebuild
                     self._nphd_indexes[unit_type] = nphd_index
@@ -1260,7 +1299,7 @@ class UsearchIndex:
                 logger.warning(f"Failed to load ShardedNphdIndex '{unit_type}': {e}. Skipping.")
 
     def _rebuild_nphd_index(self, unit_type):
-        # type: (str) -> None
+        # type: (str) -> bool
         """
         Rebuild ShardedNphdIndex from LMDB asset data.
 
@@ -1268,6 +1307,7 @@ class UsearchIndex:
         and creates fresh ShardedNphdIndex. Automatically saves and updates metadata.
 
         :param unit_type: Unit type identifier to rebuild
+        :return: True if an index was rebuilt, False if no source vectors exist
         """
         import time as time_module
 
@@ -1297,10 +1337,13 @@ class UsearchIndex:
 
         if not keys:
             logger.info(f"No vectors found for unit_type '{unit_type}' - skipping rebuild")
-            return
+            return False
 
         # Remove stale/corrupt shard directory before creating fresh index
         shard_dir = self.path / unit_type
+        old_index = self._nphd_indexes.pop(unit_type, None)
+        if old_index is not None:
+            old_index.reset()
         if shard_dir.exists():
             shutil.rmtree(shard_dir)
 
@@ -1326,6 +1369,7 @@ class UsearchIndex:
 
         elapsed = time_module.time() - start_time
         logger.info(f"Rebuilt ShardedNphdIndex for unit_type '{unit_type}': {len(keys)} vectors in {elapsed:.2f}s")
+        return True
 
     def _get_or_create_nphd_index(self, unit_type):
         # type: (str) -> ShardedNphdIndex
@@ -1411,7 +1455,8 @@ class UsearchIndex:
                     logger.warning(
                         f"UsearchSimprintIndex '{sp_type}' out of sync: "
                         f"expected {expected_count}, found {actual_count}. "
-                        f"Skipping auto-rebuild (use CLI rebuild command to fix)."
+                        f"Skipping auto-rebuild. Run 'iscc-search index rebuild "
+                        f"--simprint-type {sp_type}' (or '--all') to repair."
                     )
                     # Accept stale index rather than risk OOM during rebuild
                     self._simprint_indexes[sp_type] = sp_index
@@ -1423,18 +1468,19 @@ class UsearchIndex:
                 logger.warning(f"Failed to load UsearchSimprintIndex '{sp_type}': {e}. Skipping.")
 
     def _rebuild_simprint_index(self, sp_type):
-        # type: (str) -> None
+        # type: (str) -> bool
         """
         Rebuild ShardedIndex128 for a simprint type from LMDB source of truth.
 
         :param sp_type: Simprint type identifier to rebuild
+        :return: True if an index was rebuilt, False if no source vectors exist
         """
         start_time = time.time()
         logger.info(f"Rebuilding UsearchSimprintIndex for type '{sp_type}'...")
 
         if sp_type not in self._sp_data_dbs:
             logger.warning(f"No LMDB database for simprint type '{sp_type}' - skipping rebuild")
-            return
+            return False
 
         data_db = self._sp_data_dbs[sp_type]
 
@@ -1450,7 +1496,7 @@ class UsearchIndex:
         ndim = self._detect_sp_ndim(sp_type)
         if ndim is None:
             logger.info(f"No vectors found for simprint type '{sp_type}' - skipping rebuild")
-            return
+            return False
 
         # Iterate LMDB in batches to avoid loading all vectors into RAM
         sp_index = UsearchSimprintIndex(
@@ -1476,6 +1522,7 @@ class UsearchIndex:
 
         elapsed = time.time() - start_time
         logger.info(f"Rebuilt UsearchSimprintIndex for type '{sp_type}': {total_vectors} vectors in {elapsed:.2f}s")
+        return True
 
     def _update_sp_metadata(self, sp_type, vector_count):
         # type: (str, int) -> None

--- a/iscc_search/indexes/usearch/manager.py
+++ b/iscc_search/indexes/usearch/manager.py
@@ -8,6 +8,7 @@ Implements IsccIndexProtocol for use as backend in CLI and server.
 """
 
 import shutil
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 from loguru import logger
@@ -59,6 +60,9 @@ class UsearchIndexManager:
         self.base_path.mkdir(parents=True, exist_ok=True)
         self.max_dim = max_dim
         self._index_cache = {}  # type: dict[str, UsearchIndex]
+        # Serialize first-load construction so concurrent requests don't race on lmdb.open()
+        # (which raises "already open in this process" if two threads call it simultaneously).
+        self._cache_lock = threading.Lock()
 
     def list_indexes(self):
         # type: () -> list[IsccIndex]
@@ -212,6 +216,28 @@ class UsearchIndexManager:
         idx = self._get_or_load_index(index_name)
         return idx.search_assets(query, limit)
 
+    def rebuild(self, name, unit_types=None, simprint_types=None):
+        # type: (str, list[str] | None, list[str] | None) -> dict
+        """
+        Rebuild derived NPHD/simprint indexes for the named index from LMDB source.
+
+        ``None`` for ``unit_types`` or ``simprint_types`` means "rebuild every type
+        of that kind currently tracked in LMDB metadata".
+
+        :param name: Target index name
+        :param unit_types: NPHD unit_types to rebuild, or None for all tracked
+        :param simprint_types: Simprint types to rebuild, or None for all tracked
+        :return: Dict with ``unit_types`` and ``simprint_types`` lists actually rebuilt
+        :raises FileNotFoundError: If index doesn't exist
+        """
+        self._validate_index_exists(name)
+        idx = self._get_or_load_index(name)
+        if unit_types is None:
+            unit_types = idx.tracked_unit_types
+        if simprint_types is None:
+            simprint_types = idx.tracked_simprint_types
+        return idx.rebuild(unit_types, simprint_types)
+
     def close(self):
         # type: () -> None
         """
@@ -234,16 +260,23 @@ class UsearchIndexManager:
         """
         Get cached index or load from disk.
 
+        Thread-safe: a lock guards the cache-miss construction path so concurrent
+        first-burst requests don't race on lmdb.open() (which raises
+        "already open in this process" if two threads call it simultaneously).
+
         :param name: Index name
         :return: UsearchIndex instance
         """
         if name in self._index_cache:
             return self._index_cache[name]
 
-        index_path = self.base_path / name
-        idx = UsearchIndex(index_path, max_dim=self.max_dim)
-        self._index_cache[name] = idx
-        return idx
+        with self._cache_lock:
+            if name in self._index_cache:
+                return self._index_cache[name]
+            index_path = self.base_path / name
+            idx = UsearchIndex(index_path, max_dim=self.max_dim)
+            self._index_cache[name] = idx
+            return idx
 
     def _validate_index_exists(self, name):
         # type: (str) -> None

--- a/iscc_search/options.py
+++ b/iscc_search/options.py
@@ -164,7 +164,7 @@ class SearchOptions(BaseSettings):
 
     # Flush control
     flush_interval: int = Field(
-        0,
+        100000,
         ge=0,
         description="ISCC_SEARCH_FLUSH_INTERVAL - Auto-flush sub-indexes after N dirty key "
         "mutations (0 = disabled). Only safe with a single writer process.",

--- a/iscc_search/options.py
+++ b/iscc_search/options.py
@@ -85,13 +85,13 @@ class SearchOptions(BaseSettings):
 
     # Shard sizes (in MB)
     shard_size_units: int = Field(
-        1024,
+        512,
         ge=1,
         description="ISCC_SEARCH_SHARD_SIZE_UNITS - Maximum shard file size for unit indexes in MB",
     )
 
     shard_size_simprints: int = Field(
-        1024,
+        512,
         ge=1,
         description="ISCC_SEARCH_SHARD_SIZE_SIMPRINTS - Maximum shard file size for simprint indexes in MB",
     )

--- a/tests/test_cli_index.py
+++ b/tests/test_cli_index.py
@@ -1,9 +1,12 @@
 """Tests for CLI index management commands."""
 
+import iscc_core as ic
 import pytest
 
-from iscc_search.cli.index import remove_command
+from iscc_search.cli.index import rebuild_command, remove_command
 from iscc_search.config import ConfigManager, LocalIndexConfig
+from iscc_search.indexes.usearch import UsearchIndexManager
+from iscc_search.schema import IsccEntry, IsccIndex
 
 
 @pytest.fixture
@@ -119,3 +122,162 @@ def test_remove_command_with_delete_data_handles_missing_directory(config_manage
     indexes = config_manager.list_indexes()
     names = [name for name, _, _ in indexes]
     assert "ghost" not in names
+
+
+# Rebuild command tests
+
+
+@pytest.fixture
+def populated_usearch_index(tmp_path, sample_iscc_ids):
+    # type: (Path, list[str]) -> tuple[Path, str]
+    """
+    Create a populated UsearchIndex on disk that can be re-opened by tests.
+
+    Returns the base_path and the index name.
+    """
+    base_path = tmp_path / "indexes"
+    mgr = UsearchIndexManager(base_path)
+    name = "rebuilder"
+    mgr.create_index(IsccIndex(name=name))
+
+    content_unit = ic.gen_text_code_v0("Test content for CLI rebuild")["iscc"]
+    instance_unit = f"ISCC:{ic.Code.rnd(ic.MT.INSTANCE, bits=128)}"
+    asset = IsccEntry(
+        iscc_id=sample_iscc_ids[0],
+        units=[instance_unit, content_unit],
+    )
+    mgr.add_assets(name, [asset])
+    mgr.close()
+    return base_path, name
+
+
+@pytest.fixture
+def patched_active_index(monkeypatch, populated_usearch_index):
+    # type: (pytest.MonkeyPatch, tuple) -> tuple[Path, str]
+    """
+    Patch get_active_index to return a fresh UsearchIndexManager on the populated path.
+
+    Each call gets a new manager (matching real CLI behavior where each command instantiates
+    one). The manager is closed by the rebuild_command itself.
+    """
+    base_path, name = populated_usearch_index
+
+    def fake_get_active_index(index_name=None):
+        # type: (str | None) -> tuple
+        target = index_name or name
+        return UsearchIndexManager(base_path), target
+
+    monkeypatch.setattr("iscc_search.cli.index.get_active_index", fake_get_active_index)
+    return base_path, name
+
+
+def test_rebuild_requires_at_least_one_target(patched_active_index):
+    """Bare `index rebuild` (no flags) should exit with an error."""
+    with pytest.raises(SystemExit) as exc_info:
+        rebuild_command(unit_type=[], simprint_type=[], all_types=False, index_name=None)
+    assert exc_info.value.code == 1
+
+
+def test_rebuild_all_with_explicit_types_is_rejected(patched_active_index):
+    """`--all` combined with `--unit-type` should exit with an error (ambiguous intent)."""
+    with pytest.raises(SystemExit) as exc_info:
+        rebuild_command(
+            unit_type=["CONTENT_TEXT_V0"],
+            simprint_type=[],
+            all_types=True,
+            index_name=None,
+        )
+    assert exc_info.value.code == 1
+
+
+def test_rebuild_all_succeeds_on_local_usearch(patched_active_index):
+    """`--all` on a populated usearch index rebuilds every tracked NPHD type."""
+    rebuild_command(unit_type=[], simprint_type=[], all_types=True, index_name=None)
+
+
+def test_rebuild_specific_unit_type(patched_active_index):
+    """`--unit-type X` rebuilds only X."""
+    rebuild_command(
+        unit_type=["CONTENT_TEXT_V0"],
+        simprint_type=[],
+        all_types=False,
+        index_name=None,
+    )
+
+
+def test_rebuild_unknown_unit_type_prints_nothing_rebuilt(patched_active_index, capsys):
+    """`--unit-type` typos should not be reported as successful rebuilds."""
+    rebuild_command(
+        unit_type=["CONTENT_TXT_V0"],
+        simprint_type=[],
+        all_types=False,
+        index_name=None,
+    )
+
+    captured = capsys.readouterr()
+    assert "nothing rebuilt" in captured.out
+    assert "Rebuilt NPHD" not in captured.out
+
+
+def test_rebuild_with_no_tracked_types_prints_yellow(monkeypatch, tmp_path):
+    """An empty tracked-types result (--all on an empty index) should NOT exit nonzero."""
+    base_path = tmp_path / "indexes"
+    mgr = UsearchIndexManager(base_path)
+    mgr.create_index(IsccIndex(name="empty"))
+    mgr.close()
+
+    def fake_get_active_index(index_name=None):
+        # type: (str | None) -> tuple
+        return UsearchIndexManager(base_path), "empty"
+
+    monkeypatch.setattr("iscc_search.cli.index.get_active_index", fake_get_active_index)
+
+    rebuild_command(unit_type=[], simprint_type=[], all_types=True, index_name=None)
+
+
+def test_rebuild_rejects_remote_index(monkeypatch):
+    """Rebuild against a non-UsearchIndexManager (e.g. remote client) must error out."""
+
+    class FakeRemote:
+        def close(self):  # pragma: no cover - never reached because we error before close
+            pass
+
+    def fake_get_active_index(index_name=None):
+        # type: (str | None) -> tuple
+        return FakeRemote(), "remote-name"
+
+    monkeypatch.setattr("iscc_search.cli.index.get_active_index", fake_get_active_index)
+
+    with pytest.raises(SystemExit) as exc_info:
+        rebuild_command(unit_type=[], simprint_type=[], all_types=True, index_name=None)
+    assert exc_info.value.code == 1
+
+
+def test_rebuild_propagates_index_not_found(monkeypatch, tmp_path):
+    """If get_active_index returns a manager but the index doesn't exist, exit nonzero."""
+    base_path = tmp_path / "indexes"
+    base_path.mkdir()
+
+    def fake_get_active_index(index_name=None):
+        # type: (str | None) -> tuple
+        return UsearchIndexManager(base_path), "ghost"
+
+    monkeypatch.setattr("iscc_search.cli.index.get_active_index", fake_get_active_index)
+
+    with pytest.raises(SystemExit) as exc_info:
+        rebuild_command(unit_type=[], simprint_type=[], all_types=True, index_name=None)
+    assert exc_info.value.code == 1
+
+
+def test_rebuild_handles_get_active_index_error(monkeypatch):
+    """A ValueError from get_active_index (e.g. no active index configured) exits nonzero."""
+
+    def fake_get_active_index(index_name=None):
+        # type: (str | None) -> tuple
+        raise ValueError("No active index configured")
+
+    monkeypatch.setattr("iscc_search.cli.index.get_active_index", fake_get_active_index)
+
+    with pytest.raises(SystemExit) as exc_info:
+        rebuild_command(unit_type=[], simprint_type=[], all_types=True, index_name=None)
+    assert exc_info.value.code == 1

--- a/tests/test_indexes_lmdb_manager.py
+++ b/tests/test_indexes_lmdb_manager.py
@@ -4,6 +4,8 @@ Tests for LmdbIndexManager protocol implementation.
 Tests full protocol compliance, index lifecycle management, and multi-index scenarios.
 """
 
+import threading
+
 import pytest
 from iscc_search.schema import IsccIndex, IsccEntry, IsccQuery
 from iscc_search.indexes.lmdb import LmdbIndexManager
@@ -295,6 +297,48 @@ def test_get_file_size_mb(manager, tmp_path, sample_assets):
 
     assert isinstance(size_mb, int)
     assert size_mb >= 0
+
+
+def test_concurrent_get_or_load_index_does_not_race_on_lmdb_open(manager, tmp_path, sample_assets):
+    """
+    Concurrent first-load requests for the same uncached index must serialize
+    on the cache lock so lmdb.open() runs exactly once. Without the lock,
+    a parallel call to lmdb.open on the same path raises:
+    "The environment ... is already open in this process".
+    """
+    # Create the index file on disk and drop the cached instance so the next
+    # access goes through the cache-miss path concurrently. Close the popped
+    # instance because LMDB does not allow the same path to be opened twice in
+    # the same process, which is precisely the race being exercised here.
+    manager.create_index(IsccIndex(name="concurrent"))
+    cached = manager._index_cache.pop("concurrent")
+    cached.close()
+
+    barrier = threading.Barrier(8)
+    results = []  # type: list
+    errors = []  # type: list
+
+    def worker():
+        # type: () -> None
+        try:
+            barrier.wait()
+            idx = manager._get_or_load_index("concurrent")
+            results.append(idx)
+        except Exception as e:  # pragma: no cover - test would fail below if this triggers
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert len(results) == 8
+    # All workers must observe the same cached instance (i.e. only one was constructed).
+    first = results[0]
+    assert all(r is first for r in results)
+    assert manager._index_cache["concurrent"] is first
 
 
 def test_list_indexes_with_assets(manager, sample_assets):

--- a/tests/test_indexes_usearch_manager.py
+++ b/tests/test_indexes_usearch_manager.py
@@ -5,6 +5,8 @@ Tests full protocol compliance, index lifecycle management, hybrid LMDB/NphdInde
 and INSTANCE special handling.
 """
 
+import threading
+
 import iscc_core as ic
 import pytest
 from iscc_search.schema import IsccIndex, IsccEntry, IsccQuery, Status
@@ -407,6 +409,142 @@ def test_persistence_after_close(manager, tmp_path, sample_iscc_ids, sample_cont
         assert len(result.global_matches) > 0
     finally:
         manager2.close()
+
+
+def test_concurrent_get_or_load_index_does_not_race_on_lmdb_open(manager, sample_iscc_ids, sample_content_units):
+    """
+    Concurrent first-load requests for the same uncached index must serialize
+    on the cache lock so lmdb.open() runs exactly once. Without the lock,
+    the second concurrent lmdb.open on the same path raises:
+    "The environment ... is already open in this process".
+    """
+    # Create the index on disk WITHOUT keeping it cached, so the next access
+    # goes through the cache-miss path concurrently from multiple threads.
+    manager.create_index(IsccIndex(name="concurrent"))
+    cached = manager._index_cache.pop("concurrent")
+    cached.close()
+
+    barrier = threading.Barrier(8)
+    results = []  # type: list
+    errors = []  # type: list
+
+    def worker():
+        # type: () -> None
+        try:
+            barrier.wait()
+            idx = manager._get_or_load_index("concurrent")
+            results.append(idx)
+        except Exception as e:  # pragma: no cover - test would fail below if this triggers
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert len(results) == 8
+    first = results[0]
+    assert all(r is first for r in results)
+    assert manager._index_cache["concurrent"] is first
+
+
+def test_rebuild_all_known_types(manager, sample_iscc_ids, sample_content_units):
+    """Rebuild with both lists None should rebuild every tracked type."""
+    manager.create_index(IsccIndex(name="rebuildme"))
+    asset = IsccEntry(
+        iscc_id=sample_iscc_ids[0],
+        units=[sample_content_units[0], sample_content_units[1]],
+    )
+    manager.add_assets("rebuildme", [asset])
+
+    result = manager.rebuild("rebuildme")
+
+    # Two CONTENT-type units → both go to NPHD; no simprints provided
+    assert sorted(result["unit_types"]) == sorted(set(result["unit_types"]))
+    assert any(ut.startswith("CONTENT_") for ut in result["unit_types"])
+    assert result["simprint_types"] == []
+
+
+def test_rebuild_specific_unit_type_only(manager, sample_iscc_ids, sample_content_units):
+    """Rebuild with explicit unit_types should only rebuild those types."""
+    manager.create_index(IsccIndex(name="rebuildme"))
+    asset = IsccEntry(
+        iscc_id=sample_iscc_ids[0],
+        units=[sample_content_units[0], sample_content_units[1]],
+    )
+    manager.add_assets("rebuildme", [asset])
+
+    # Pick the first NPHD unit_type that exists
+    idx = manager._get_or_load_index("rebuildme")
+    target = idx.tracked_unit_types[0]
+
+    result = manager.rebuild("rebuildme", unit_types=[target], simprint_types=[])
+
+    assert result == {"unit_types": [target], "simprint_types": []}
+
+
+def test_rebuild_explicit_unknown_types_returns_empty(manager, sample_iscc_ids, sample_content_units):
+    """Explicit typo targets should not be reported as rebuilt."""
+    manager.create_index(IsccIndex(name="rebuildme"))
+    asset = IsccEntry(
+        iscc_id=sample_iscc_ids[0],
+        units=[sample_content_units[0], sample_content_units[1]],
+    )
+    manager.add_assets("rebuildme", [asset])
+
+    result = manager.rebuild(
+        "rebuildme",
+        unit_types=["CONTENT_TXT_V0"],
+        simprint_types=["CONTENT_TXT_V0"],
+    )
+
+    assert result == {"unit_types": [], "simprint_types": []}
+
+
+def test_rebuild_all_skips_tracked_unit_type_without_vectors(manager):
+    """Tracked NPHD metadata without LMDB source vectors should not count as rebuilt."""
+    manager.create_index(IsccIndex(name="rebuildme"))
+    idx = manager._get_or_load_index("rebuildme")
+    idx._update_nphd_metadata("CONTENT_TEXT_V0", 1)
+
+    result = manager.rebuild("rebuildme")
+
+    assert result == {"unit_types": [], "simprint_types": []}
+
+
+def test_rebuild_all_skips_tracked_simprint_type_without_database(manager):
+    """Tracked simprint metadata without an opened LMDB source DB should not count as rebuilt."""
+    manager.create_index(IsccIndex(name="rebuildme"))
+    idx = manager._get_or_load_index("rebuildme")
+    with idx.env.begin(write=True) as txn:
+        metadata_db = idx.env.open_db(b"__metadata__", txn=txn)
+        txn.put(b"sp_types", b'["CONTENT_TEXT_V0"]', db=metadata_db)
+
+    result = manager.rebuild("rebuildme")
+
+    assert result == {"unit_types": [], "simprint_types": []}
+
+
+def test_rebuild_index_not_found(manager):
+    """rebuild on missing index raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError, match="not found"):
+        manager.rebuild("ghost")
+
+
+def test_rebuild_simprint_types(manager, sample_assets_with_simprints):
+    """Rebuild simprint types — exercises the second loop in UsearchIndex.rebuild."""
+    manager.create_index(IsccIndex(name="rebuildsp"))
+    manager.add_assets("rebuildsp", sample_assets_with_simprints)
+
+    idx = manager._get_or_load_index("rebuildsp")
+    sp_targets = idx.tracked_simprint_types
+    assert sp_targets, "fixture should add at least one simprint type"
+
+    result = manager.rebuild("rebuildsp", unit_types=[], simprint_types=sp_targets)
+
+    assert result == {"unit_types": [], "simprint_types": sp_targets}
 
 
 def test_multiple_indexes_isolation(manager, sample_iscc_ids, sample_content_units):

--- a/tests/test_indexes_usearch_persistence.py
+++ b/tests/test_indexes_usearch_persistence.py
@@ -187,9 +187,10 @@ def test_usearch_index_rebuild_with_no_vectors(tmp_path, sample_iscc_ids):
     idx.add_assets([asset])
 
     # Trigger rebuild for non-existent unit_type
-    idx._rebuild_nphd_index("NONEXISTENT_TYPE")
+    rebuilt = idx._rebuild_nphd_index("NONEXISTENT_TYPE")
 
     # Should complete without error, no index created
+    assert rebuilt is False
     assert "NONEXISTENT_TYPE" not in idx._nphd_indexes
 
     idx.close()
@@ -216,8 +217,9 @@ def test_usearch_index_rebuild_without_existing_dir(tmp_path, sample_iscc_ids):
     assert not shard_dir.exists()
 
     # Rebuild — should create directory from scratch (exercises shard_dir.exists()=False branch)
-    idx._rebuild_nphd_index(unit_type)
+    rebuilt = idx._rebuild_nphd_index(unit_type)
 
+    assert rebuilt is True
     assert unit_type in idx._nphd_indexes
     assert idx._nphd_indexes[unit_type].size == 1
 
@@ -246,10 +248,55 @@ def test_usearch_index_rebuild_with_existing_dir(tmp_path, sample_iscc_ids):
     del idx._nphd_indexes[unit_type]
 
     # Rebuild — should remove stale dir first (exercises shard_dir.exists()=True branch)
-    idx._rebuild_nphd_index(unit_type)
+    rebuilt = idx._rebuild_nphd_index(unit_type)
 
+    assert rebuilt is True
     assert unit_type in idx._nphd_indexes
     assert idx._nphd_indexes[unit_type].size == 1
+
+    idx.close()
+
+
+def test_usearch_index_rebuild_resets_cached_nphd_before_delete(tmp_path, sample_iscc_ids, monkeypatch):
+    """Cached NPHD indexes are released before their shard directory is removed."""
+    index_path = tmp_path / "rebuild_cached_release"
+
+    idx = UsearchIndex(index_path, realm_id=0, max_dim=256)
+
+    content_unit = ic.gen_text_code_v0("Test content for cached rebuild release")["iscc"]
+    instance_unit = f"ISCC:{ic.Code.rnd(ic.MT.INSTANCE, bits=128)}"
+    asset = IsccEntry(iscc_id=sample_iscc_ids[0], units=[instance_unit, content_unit])
+    idx.add_assets([asset])
+    idx.flush()
+
+    unit_type = "CONTENT_TEXT_V0"
+    real_index = idx._nphd_indexes[unit_type]
+    real_index.reset()
+
+    reset_called = False
+
+    class CachedIndex:
+        def reset(self):
+            # type: () -> None
+            nonlocal reset_called
+            reset_called = True
+
+    idx._nphd_indexes[unit_type] = CachedIndex()
+
+    original_rmtree = shutil.rmtree
+
+    def rmtree_spy(path):
+        assert reset_called is True
+        original_rmtree(path)
+
+    monkeypatch.setattr("iscc_search.indexes.usearch.index.shutil.rmtree", rmtree_spy)
+
+    rebuilt = idx._rebuild_nphd_index(unit_type)
+
+    assert rebuilt is True
+    assert reset_called is True
+    assert unit_type in idx._nphd_indexes
+    assert idx._nphd_indexes[unit_type] is not real_index
 
     idx.close()
 

--- a/tests/test_indexes_usearch_simprint_approx.py
+++ b/tests/test_indexes_usearch_simprint_approx.py
@@ -948,7 +948,8 @@ def test_rebuild_simprint_index_no_data(tmp_path, sample_iscc_ids):
         txn.drop(data_db, delete=False)  # Clear all entries
 
     # Rebuild should handle empty gracefully
-    idx._rebuild_simprint_index(sp_type)
+    rebuilt = idx._rebuild_simprint_index(sp_type)
+    assert rebuilt is False
 
     idx.close()
 
@@ -959,7 +960,8 @@ def test_rebuild_simprint_index_unknown_type(tmp_path, sample_iscc_ids):
     idx = UsearchIndex(index_path, realm_id=0, max_dim=256)
 
     # Rebuild for type that doesn't exist in _sp_data_dbs
-    idx._rebuild_simprint_index("NONEXISTENT_V0")
+    rebuilt = idx._rebuild_simprint_index("NONEXISTENT_V0")
+    assert rebuilt is False
 
     idx.close()
 
@@ -1143,9 +1145,10 @@ def test_rebuild_with_existing_directory(tmp_path, sample_iscc_ids):
     assert sp_dir.exists()
 
     # Rebuild with existing directory
-    idx._rebuild_simprint_index(sp_type)
+    rebuilt = idx._rebuild_simprint_index(sp_type)
 
     # Verify rebuild succeeded
+    assert rebuilt is True
     assert sp_type in idx._simprint_indexes
     assert idx._simprint_indexes[sp_type].size == 1
 


### PR DESCRIPTION
## Summary

Patch release driven by a production incident on a customer EC2 deployment that lost data from
NPHD shard directories and ~5.2M SIMPRINT_CONTENT_TEXT vectors after an unclean shutdown.
Tightens durability defaults so the next crash does not produce the same outcome, and gives
operators a real recovery path.

### Added

- `iscc-search index rebuild [--unit-type X] [--simprint-type Y] [--all] [--index NAME]` CLI.
  Replaces the Python REPL workaround operators had to use; the "out-of-sync" startup warning
  now points at a command that actually exists.

### Changed (breaking defaults)

- `ISCC_SEARCH_FLUSH_INTERVAL`: `0` → `100000`. Caps post-crash loss to ~100K mutations per
  sub-index instead of "everything since process start." Trade-off: ~25× write amplification on
  heavy SIMPRINT ingestion. Set to `0` to restore the old behavior.
- `ISCC_SEARCH_SHARD_SIZE_UNITS` / `ISCC_SEARCH_SHARD_SIZE_SIMPRINTS`: `1024` MB → `512` MB.
  Active shards seal to immutable on-disk artifacts roughly twice as often. Existing
  deployments need no migration — sealed shards stay untouched, oversized active shards
  rotate on next add.
- `compose.yaml` `stop_grace_period`: `90s` → `300s`. Required so the lifespan flush actually
  completes on shutdown. Production compose files that override this must be recalculated:
  `>= timeout_graceful_shutdown + expected_flush_duration`.

### Fixed

- LMDB concurrent-open race in `UsearchIndexManager` / `LmdbIndexManager._get_or_load_index`.
  First-burst-after-restart no longer produces 500s with `lmdb.Error: ... already open`.
- Deployment troubleshooting docs no longer instruct operators to delete `.usearch` files
  (auto-rebuild on startup was disabled in 0.1.0; the old advice produced exactly the failure
  state observed in the incident).

## Operator action required

Customers running their own `docker-compose.yml` must add to their compose file:

```yaml
services:
  iscc-search:
    image: ghcr.io/iscc/iscc-search:0.1.1   # pin, do not use :latest in prod
    stop_grace_period: 300s                 # without this, Docker's 10s default kills the flush
    environment:
      - ISCC_SEARCH_FLUSH_INTERVAL=100000   # already the new default but make it explicit
```

## Test plan

- [x] All four CI matrix combinations green on develop @ 11bdcd4 (Linux py3.11-3.14, macOS py3.12, Windows py3.12)
- [x] Wheel build + smoke test green
- [x] Docker image build + smoke test green
- [x] `uv run poe test` locally
- [ ] Post-merge: main CI green before tagging
- [ ] Post-release: PyPI install smoke check
- [ ] Post-release: `docker pull ghcr.io/iscc/iscc-search:v0.1.1` smoke check
- [ ] Post-release: docs site (search.iscc.codes) returns 200