### PR TITLE
Fix macOS coverage for v0.2.0

### DIFF
--- a/iscc_search/indexes/usearch/manager.py
+++ b/iscc_search/indexes/usearch/manager.py
@@ -271,7 +271,7 @@ class UsearchIndexManager:
             return self._index_cache[name]
 
         with self._cache_lock:
-            if name in self._index_cache:
+            if name in self._index_cache:  # pragma: no cover - race condition guard
                 return self._index_cache[name]
             index_path = self.base_path / name
             idx = UsearchIndex(index_path, max_dim=self.max_dim)


### PR DESCRIPTION
## Summary

- Mark UsearchManager double-checked locking guard as `no cover` (same fix as 7e561b1 for LmdbManager)

Fixes macOS CI coverage failure blocking the v0.2.0 release.